### PR TITLE
set up path_aliases and mountpath to avoid issues with path detection

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -44,7 +44,7 @@ presets:
       - name: CLOUDSDK_DNS_ZONE_NAME
         value: "prow-dev" #GCloud DNS Zone Name (NOT it's DNS name!)
       - name: KYMA_PROW_DNS_NAME
-        value: "a.build.kyma-project.io."
+        value: "prow.build.kyma-project.io."
       - name: KYMA_PROJECT_DIR
         value: "/home/prow/go/src/github.com/kyma-project"
     volumes:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,6 +43,8 @@ presets:
         value: /etc/credentials/upgrade-sa-gke-kyma-integratio/service-account.json
       - name: CLOUDSDK_DNS_ZONE_NAME
         value: "prow-dev" #GCloud DNS Zone Name (NOT it's DNS name!)
+      - name: KYMA_PROW_DNS_NAME
+        value: "a.build.kyma-project.io."
       - name: KYMA_PROJECT_DIR
         value: "/home/prow/go/src/github.com/kyma-project"
     volumes:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -44,7 +44,7 @@ presets:
       - name: CLOUDSDK_DNS_ZONE_NAME
         value: "prow-dev" #GCloud DNS Zone Name (NOT it's DNS name!)
       - name: KYMA_PROJECT_DIR
-        value: "/home/prow/go/src/github.com/kyma-test-infra-dev"
+        value: "/home/prow/go/src/github.com/kyma-project"
     volumes:
       - name: upgrade-sa-gke-kyma-integratio
         secret:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,7 +43,7 @@ presets:
         value: /etc/credentials/upgrade-sa-gke-kyma-integratio/service-account.json
       - name: CLOUDSDK_DNS_ZONE_NAME
         value: "prow-dev" #GCloud DNS Zone Name (NOT it's DNS name!)
-      - name: KYMA_PROW_DNS_NAME
+      - name: KYMA_DNS_NAME
         value: "prow.build.kyma-project.io."
       - name: KYMA_PROJECT_DIR
         value: "/home/prow/go/src/github.com/kyma-project"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -3,12 +3,12 @@
 test_infra_ref: &test_infra_ref
   org: kyma-test-infra-dev
   repo: test-infra
-  path_alias: github.com/kyma-test-infra-dev/test-infra
+  path_alias: github.com/kyma-project/test-infra
 
 kyma_ref: &kyma_ref
   org: kyma-test-infra-dev
   repo: kyma
-  path_alias: github.com/kyma-test-infra-dev/kyma
+  path_alias: github.com/kyma-project/kyma
 
 # Kubectl 1.14
 base_image_k14: &base_image_k14
@@ -138,7 +138,7 @@ gke_minio_gateway_migration_job_template: &gke_minio_gateway_migration_job_templ
 gke_job_template: &gke_job_template
   skip_report: false
   decorate: true
-  path_alias: github.com/kyma-test-infra-dev/kyma
+  path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   spec:
     containers:
@@ -488,7 +488,7 @@ presubmits: # runs on PRs
       extra_refs:
         - org: kyma-test-infra-dev
           repo: test-infra
-          path_alias: github.com/kyma-test-infra-dev/test-infra
+          path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.8
 
     - name: pre-master-kyma-gke-upgrade
@@ -989,7 +989,7 @@ periodics:
       - org: kyma-test-infra-dev
         repo: test-infra
         base_ref: master
-        path_alias: github.com/kyma-test-infra-dev/test-infra
+        path_alias: github.com/kyma-project/test-infra
       - <<: *kyma_ref
         base_ref: master
     spec:
@@ -1003,7 +1003,7 @@ periodics:
             privileged: true
           volumeMounts:
             - name: upgrade-sa-stability-fluentd-s
-              mountPath: /etc/credentials/upgrade-sa-stability-fluentd-s
+              mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
               readOnly: true
           command:
             - "bash"
@@ -1073,7 +1073,7 @@ periodics:
             privileged: true
           volumeMounts:
             - name: upgrade-sa-stability-fluentd-s
-              mountPath: /etc/credentials/upgrade-sa-stability-fluentd-s
+              mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
               readOnly: true
           command:
             - "bash"
@@ -1144,7 +1144,7 @@ periodics:
             privileged: true
           volumeMounts:
             - name: upgrade-sa-stability-fluentd-s
-              mountPath: /etc/credentials/upgrade-sa-stability-fluentd-s
+              mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
               readOnly: true
           env:
             - <<: *cluster_version_k15
@@ -1187,7 +1187,7 @@ periodics:
       - org: kyma-test-infra-dev
         repo: test-infra
         base_ref: master
-        path_alias: github.com/kyma-test-infra-dev/test-infra
+        path_alias: github.com/kyma-project/test-infra
       - <<: *kyma_ref
         base_ref: master
     spec:

--- a/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
@@ -8,19 +8,19 @@
 # - TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS: absolute path for test-infra/prow/scripts/cluster-integration/helpers directory
 # - CLOUDSDK_COMPUTE_REGION: region where the GKE cluster is e.g. europe-west1-b
 # - CLOUDSDK_DNS_ZONE_NAME: dns zone
+# - KYMA_PROW_DNS_NAME: dns name [with dot at the end]
 #
 #Permissions: In order to run this script you need to use a service account with "Compute Admin,DNS Administrator, Kubernetes Engine Admin, Kubernetes Engine Cluster Admin, Service Account User, Storage Admin" role
 
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
-DNS_NAME="a.build.kyma-project.io."
 
 function cleanup() {
 	
 	shout "Running cleanup-cluster process"
 	discoverUnsetVar=false
 
-	for var in CLUSTER_NAME TEST_INFRA_SOURCES_DIR TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS CLOUDSDK_COMPUTE_REGION CLOUDSDK_DNS_ZONE_NAME; do
+	for var in CLUSTER_NAME TEST_INFRA_SOURCES_DIR TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS CLOUDSDK_COMPUTE_REGION CLOUDSDK_DNS_ZONE_NAME KYMA_PROW_DNS_NAME; do
 		if [ -z "${!var}" ] ; then
 			echo "ERROR: $var is not set"
 			discoverUnsetVar=true
@@ -103,7 +103,7 @@ function removeResources() {
 
 		shout "Delete Cluster DNS Record"
 		date
-		GATEWAY_DNS_FULL_NAME="*.${CLUSTER_NAME}.${DNS_NAME}"
+		GATEWAY_DNS_FULL_NAME="*.${CLUSTER_NAME}.${KYMA_PROW_DNS_NAME}"
 		# Get cluster IP address from DNS record.
 		GATEWAY_IP_ADDRESS=$(gcloud dns record-sets list --zone "${CLOUDSDK_DNS_ZONE_NAME}" --name "${GATEWAY_DNS_FULL_NAME}" --format "value(rrdatas[0])")
 
@@ -120,7 +120,7 @@ function removeResources() {
 
 		shout "Delete Apiserver DNS Record"
 		date
-		APISERVER_DNS_FULL_NAME="apiserver.${CLUSTER_NAME}.${DNS_NAME}"
+		APISERVER_DNS_FULL_NAME="apiserver.${CLUSTER_NAME}.${KYMA_PROW_DNS_NAME}"
 		# Get apiserver IP address from DNS record.
 		APISERVER_IP_ADDRESS=$(gcloud dns record-sets list --zone "${CLOUDSDK_DNS_ZONE_NAME}" --name "${APISERVER_DNS_FULL_NAME}" --format="value(rrdatas[0])")
 

--- a/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
@@ -8,7 +8,7 @@
 # - TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS: absolute path for test-infra/prow/scripts/cluster-integration/helpers directory
 # - CLOUDSDK_COMPUTE_REGION: region where the GKE cluster is e.g. europe-west1-b
 # - CLOUDSDK_DNS_ZONE_NAME: dns zone
-# - KYMA_PROW_DNS_NAME: dns name [with dot at the end]
+# - KYMA_DNS_NAME: dns name [with dot at the end]
 #
 #Permissions: In order to run this script you need to use a service account with "Compute Admin,DNS Administrator, Kubernetes Engine Admin, Kubernetes Engine Cluster Admin, Service Account User, Storage Admin" role
 
@@ -20,7 +20,7 @@ function cleanup() {
 	shout "Running cleanup-cluster process"
 	discoverUnsetVar=false
 
-	for var in CLUSTER_NAME TEST_INFRA_SOURCES_DIR TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS CLOUDSDK_COMPUTE_REGION CLOUDSDK_DNS_ZONE_NAME KYMA_PROW_DNS_NAME; do
+	for var in CLUSTER_NAME TEST_INFRA_SOURCES_DIR TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS CLOUDSDK_COMPUTE_REGION CLOUDSDK_DNS_ZONE_NAME KYMA_DNS_NAME; do
 		if [ -z "${!var}" ] ; then
 			echo "ERROR: $var is not set"
 			discoverUnsetVar=true
@@ -103,7 +103,7 @@ function removeResources() {
 
 		shout "Delete Cluster DNS Record"
 		date
-		GATEWAY_DNS_FULL_NAME="*.${CLUSTER_NAME}.${KYMA_PROW_DNS_NAME}"
+		GATEWAY_DNS_FULL_NAME="*.${CLUSTER_NAME}.${KYMA_DNS_NAME}"
 		# Get cluster IP address from DNS record.
 		GATEWAY_IP_ADDRESS=$(gcloud dns record-sets list --zone "${CLOUDSDK_DNS_ZONE_NAME}" --name "${GATEWAY_DNS_FULL_NAME}" --format "value(rrdatas[0])")
 
@@ -120,7 +120,7 @@ function removeResources() {
 
 		shout "Delete Apiserver DNS Record"
 		date
-		APISERVER_DNS_FULL_NAME="apiserver.${CLUSTER_NAME}.${KYMA_PROW_DNS_NAME}"
+		APISERVER_DNS_FULL_NAME="apiserver.${CLUSTER_NAME}.${KYMA_DNS_NAME}"
 		# Get apiserver IP address from DNS record.
 		APISERVER_IP_ADDRESS=$(gcloud dns record-sets list --zone "${CLOUDSDK_DNS_ZONE_NAME}" --name "${APISERVER_DNS_FULL_NAME}" --format="value(rrdatas[0])")
 

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -1,12 +1,12 @@
 test_infra_ref: &test_infra_ref
   org: kyma-test-infra-dev
   repo: test-infra
-  path_alias: github.com/kyma-test-infra-dev/test-infra
+  path_alias: github.com/kyma-project/test-infra
 
 kyma_ref: &kyma_ref
   org: kyma-test-infra-dev
   repo: kyma
-  path_alias: github.com/kyma-test-infra-dev/kyma
+  path_alias: github.com/kyma-project/kyma
 
 # Kubectl 1.14
 base_image_k14: &base_image_k14
@@ -963,7 +963,7 @@ periodics:
       - org: kyma-test-infra-dev
         repo: test-infra
         base_ref: master
-        path_alias: github.com/kyma-test-infra-dev/test-infra
+        path_alias: github.com/kyma-project/test-infra
       - <<: *kyma_ref
         base_ref: master
     spec:
@@ -1109,7 +1109,7 @@ periodics:
         base_ref: master
     spec:
       volumes:
-        - name: sa-stability-fluentd-storage-writer
+        - name: upgrade-sa-stability-fluentd-s
           secret:
             secretName: upgrade-sa-stability-fluentd-s
       containers:
@@ -1117,7 +1117,7 @@ periodics:
           securityContext:
             privileged: true
           volumeMounts:
-            - name: sa-stability-fluentd-storage-writer
+            - name: upgrade-sa-stability-fluentd-s
               mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
               readOnly: true
           env:
@@ -1161,7 +1161,7 @@ periodics:
       - org: kyma-test-infra-dev
         repo: test-infra
         base_ref: master
-        path_alias: github.com/kyma-test-infra-dev/test-infra
+        path_alias: github.com/kyma-project/test-infra
       - <<: *kyma_ref
         base_ref: master
     spec:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
**Description**
It is needed to use path aliases that match the ones in our production env because of some dep resolving issues and reverted renaming mountPath of `upgrade-sa-stability-fluentd-s` because the mountpath is used in a script so in order to avoid changing a lot of scripts that use hardcoded path and adding another preset we can leave the original mountpath and only change secret and volume name.
`7884b3425409ddd28bd72a9499de03a79ef4c3b5` contains resolved hardcoded DNS name in cleanup script.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
